### PR TITLE
Adding Cross Country Mapping IND-US - Refactor India pipeline and add Exiobase industry_id alignment

### DIFF
--- a/India_data/README.md
+++ b/India_data/README.md
@@ -104,28 +104,28 @@ Place your India data files in the `India_data` folder (or specify with `--data-
 
 ```bash
 # From tradeflow directory
-python india-state-allocation.py
+python india/main.py
 ```
 
 This will:
 - Look for data in `../India_data` folder
 - Use year from `config.yaml`
-- Save outputs to `year/{year}/IN/state_allocation/`
+- Save outputs to `../../trade-data/year/{year}/IN/domestic/` (per `config.yaml` `FOLDERS.domestic`)
 
 ### Advanced Usage
 
 ```bash
 # Specify custom data directory
-python india-state-allocation.py --data-dir /path/to/India_data
+python india/main.py --data-dir /path/to/India_data
 
 # Specify year
-python india-state-allocation.py --year 2019
+python india/main.py --year 2019
 
 # Specify output directory
-python india-state-allocation.py --output-dir /path/to/output
+python india/main.py --output-dir /path/to/output
 
 # Combine options
-python india-state-allocation.py --data-dir ../India_data --year 2019 --output-dir ./output
+python india/main.py --data-dir ../India_data --year 2019 --output-dir ./output
 ```
 
 ## Processing Steps
@@ -242,13 +242,13 @@ mkdir India_data
 
 # 2. Run allocation
 cd tradeflow
-python india-state-allocation.py --data-dir ../India_data --year 2019
+python india/main.py --data-dir ../India_data --year 2019
 
 # 3. Check outputs
-ls -la ../../trade-data/year/2019/IN/state_allocation/
+ls -la ../../trade-data/year/2019/IN/domestic/
 
 # 4. Review report
-cat ../../trade-data/year/2019/IN/state_allocation/allocation_report.md
+cat ../../trade-data/year/2019/IN/domestic/allocation_report.md
 ```
 
 ## Future Enhancements

--- a/tradeflow/config.yaml
+++ b/tradeflow/config.yaml
@@ -1,5 +1,6 @@
 NOTES:
-  1: COUNTRY.list "default" = run only incomplete ones within these 12 AU, BR, CA, CN, DE, FR, GB, IN, IT, JP, KR, US
+  1: COUNTRY.list "default" = run only incomplete ones within these 12 AU, BR, CA,
+    CN, DE, FR, GB, IN, IT, JP, KR, US
   2: COUNTRY.list "all" = run all (could take hours)
 TRADEFLOW: domestic,imports,exports
 YEAR: 2020
@@ -26,7 +27,8 @@ NODES:
     order: 45
     parent_node: exiobase
     name: US BEA Trade Flow
-    description: Runs exiobase US-BEA tradeflow integration and writes US trade-data outputs.
+    description: Runs exiobase US-BEA tradeflow integration and writes US trade-data
+      outputs.
     link: exiobase/tradeflow
     python_cmds: python us-bea.py
     output_path: ../../../trade-data/year/[year]/US/
@@ -35,6 +37,23 @@ NODES:
     dependencies: '{detected_dependencies}'
     api_keys_required: BEA_API_KEY
     data_sources: Exiobase MRIO,US BEA API,FEDEFL
+    target_repo: trade-data
+  india:
+    source_python: india/main.py
+    node_id: india
+    order: 46
+    parent_node: exiobase
+    name: India State Allocation
+    description: Disaggregates India national statistics to states/UTs and maps Indian GSVA
+      activity text and HS products to Exiobase industry_id codes shared with US trade-data
+      outputs.
+    link: exiobase/tradeflow/india
+    python_cmds: python india/main.py
+    output_path: ../../../trade-data/year/[year]/IN/domestic/
+    output_info: India state matrices; india_us_exiobase crosswalk; aligns industry_id with US MRIO
+    folder_size: unknown
+    dependencies: '{detected_dependencies}'
+    data_sources: India MOSPI GSDP/GSVA, TradeStat HS, India SUT, HS_EXIOBASE_mapping
     target_repo: trade-data
 FOLDERS:
   base: ../../trade-data/year/{year}

--- a/tradeflow/index.html
+++ b/tradeflow/index.html
@@ -6,11 +6,77 @@
 <title>Tradeflow</title>
 <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-
+<!-- ModelEarth localsite (optional). If missing, stubs below provide a working UI. Serve from http://localhost for fewest issues. -->
 <link type="text/css" rel="stylesheet" href="../../localsite/css/base.css" id="/localsite/css/base.css" />
 <script type="text/javascript" src="../../localsite/js/localsite.js?showheader=true&showsearch=true"></script>
+<script>
+(function () {
+  if (typeof loadMarkdown !== 'function') {
+    window.loadMarkdown = function (path, divId) {
+      var el = document.getElementById(divId);
+      if (!el) return;
+      el.innerHTML = '<p class="schema-loading">Loading <code>' + path + '</code>…</p>';
+      fetch(path)
+        .then(function (r) { return r.text(); })
+        .then(function (t) {
+          el.innerHTML = '<pre style="white-space:pre-wrap;font-size:13px;line-height:1.45;border:1px solid #e5e7eb;border-radius:8px;padding:12px;background:#fff">' +
+            t.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;') + '</pre>';
+        })
+        .catch(function () {
+          el.innerHTML = '<p class="schema-loading">Could not load <code>' + path + '</code>. Open this page through <strong>http://localhost</strong> (not <code>file://</code>) so relative fetches work, or read the file in the repo.</p>';
+        });
+    };
+  }
+  if (typeof waitForElm !== 'function') {
+    window.waitForElm = function (selector) {
+      return new Promise(function (resolve) {
+        var el = document.querySelector(selector);
+        if (el) { resolve(el); return; }
+        var obs = new MutationObserver(function () {
+          var e = document.querySelector(selector);
+          if (e) { obs.disconnect(); resolve(e); }
+        });
+        obs.observe(document.documentElement, { childList: true, subtree: true });
+        setTimeout(function () {
+          obs.disconnect();
+          resolve(document.querySelector(selector));
+        }, 4000);
+      });
+    };
+  }
+  if (typeof getHash !== 'function') {
+    window.getHash = function () {
+      var o = {};
+      var h = (location.hash || '').replace(/^#/, '');
+      if (!h) return o;
+      h.split('&').forEach(function (pair) {
+        var p = pair.split('=');
+        if (p[0]) o[decodeURIComponent(p[0])] = decodeURIComponent((p[1] || '').replace(/\+/g, ' '));
+      });
+      return o;
+    };
+  }
+  if (typeof goHash !== 'function') {
+    window.goHash = function (obj) {
+      var h = getHash();
+      Object.assign(h, obj);
+      var str = Object.keys(h).map(function (k) { return encodeURIComponent(k) + '=' + encodeURIComponent(h[k] == null ? '' : String(h[k])); }).join('&');
+      location.hash = str;
+    };
+  }
+  window.addEventListener('hashchange', function () {
+    document.dispatchEvent(new Event('hashChangeEvent'));
+  });
+})();
+</script>
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 
 <style>
+body { font-family: system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, sans-serif; margin: 0; color: #111; background: #f8fafc; }
+.content a { color: #2563eb; text-decoration: none; }
+.content a:hover { text-decoration: underline; }
+.contentpadding { padding: 16px 22px; max-width: 1080px; margin: 0 auto; }
+.large-list { font-size: 15px; line-height: 1.5; }
 .content table { background-color: #ddd; }
 .dark .content table { background-color: #555; }
 .content th { background-color: #ccc; }
@@ -103,10 +169,29 @@ th, td { padding: 4px 20px 4px 8px; text-align: left; border-bottom: 1px solid #
   color: #6B7280;
   font-style: italic;
 }
-table {
-  margin-top: 12px;
-  margin-bottom: 16px;
+.crosswalk-wrap table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
 }
+.crosswalk-wrap th {
+  background: #f1f5f9;
+  text-align: left;
+  padding: 10px 12px;
+  font-weight: 600;
+  border-bottom: 1px solid #e2e8f0;
+}
+.crosswalk-wrap td {
+  padding: 8px 12px;
+  border-bottom: 1px solid #f1f5f9;
+  vertical-align: top;
+}
+.crosswalk-wrap tr:hover td { background: #f8fafc; }
+.crosswalk-wrap code { font-size: 12px; background: #f1f5f9; padding: 2px 6px; border-radius: 4px; }
 </style>
 
 <script>
@@ -119,7 +204,7 @@ loadMarkdown("AGENTS.md", "agentsDiv", "_parent");
 <body>
 <div class="content contentpadding large-list">
   <div class="noprint" style="float:right;margin-top:6px">
-    <a href="https://github.com/ModelEarth/exiobase/tree/main/tradeflow"><img src="../../localsite/img/icon/github/github.png" style="width:42px"></a>
+    <a href="https://github.com/ModelEarth/exiobase/tree/main/tradeflow" title="Exiobase on GitHub"><img src="https://github.githubassets.com/favicons/favicon.png" width="36" height="36" alt="GitHub"></a>
   </div>
   <a href="../../profile/trade">Trade Profiles</a>
 
@@ -142,10 +227,18 @@ loadMarkdown("AGENTS.md", "agentsDiv", "_parent");
   <!-- Real-time schema diagram -->
   <div class="schema-panel">
     <h3>Industry Database Schema</h3>
+    <p style="margin:0 0 12px 0;font-size:13px;color:#64748b">Live table metadata loads from the Rust API at <code>http://localhost:8081</code>. If it is offline, the diagram below uses static placeholders. Start the API and refresh for row counts.</p>
     <div id="schema-diagram">
-      <div class="schema-loading" id="schemaLoading">Loading schema from Industry Database...</div>
+      <div class="schema-loading" id="schemaLoading">Loading schema from <code>/api/db/industry-schema</code>…</div>
       <svg id="schema-svg" style="display:none"></svg>
     </div>
+  </div>
+
+  <div class="schema-panel" id="crossCountryPanel">
+    <h3>Cross-country alignment (India ↔ US Exiobase <code>industry_id</code>)</h3>
+    <p style="margin:0 0 10px 0;font-size:13px;color:#64748b">Keyword mapping from Indian GSVA-style activity labels to the same 5-character <code>industry_id</code> codes used in US trade-data / MRIO outputs. Source: <code>india/india_us_exiobase_crosswalk.csv</code>.</p>
+    <div class="schema-loading" id="crossCountryLoading">Loading crosswalk…</div>
+    <div id="crossCountryTable" style="display:none;overflow-x:auto;"></div>
   </div>
 
   <div id="readmeDiv"></div>
@@ -516,8 +609,69 @@ loadMarkdown("AGENTS.md", "agentsDiv", "_parent");
     };
   }
 
+  function splitCrosswalkLine(line) {
+    var idx = [];
+    for (var i = 0; i < line.length && idx.length < 3; i++) {
+      if (line.charAt(i) === ',') idx.push(i);
+    }
+    if (idx.length < 3) return line.split(',');
+    return [
+      line.slice(0, idx[0]),
+      line.slice(idx[0] + 1, idx[1]),
+      line.slice(idx[1] + 1, idx[2]),
+      line.slice(idx[2] + 1)
+    ];
+  }
+
+  function loadCrossCountryCrosswalk() {
+    var loading = document.getElementById('crossCountryLoading');
+    var wrap = document.getElementById('crossCountryTable');
+    if (!loading || !wrap) return;
+
+    fetch('india/india_us_exiobase_crosswalk.csv')
+      .then(function (r) { return r.text(); })
+      .then(function (text) {
+        var lines = text.replace(/^\uFEFF/, '').trim().split(/\r?\n/);
+        if (!lines.length) throw new Error('empty');
+        var rows = lines.map(splitCrosswalkLine);
+        var head = rows[0];
+        var body = rows.slice(1);
+        var html = '<div class="crosswalk-wrap"><table><thead><tr>';
+        head.forEach(function (h) {
+          html += '<th>' + escapeHtml(h.trim()) + '</th>';
+        });
+        html += '</tr></thead><tbody>';
+        body.forEach(function (r) {
+          html += '<tr>';
+          for (var c = 0; c < head.length; c++) {
+            var cell = (r[c] != null) ? r[c].trim() : '';
+            if (c === 1) {
+              html += '<td><code>' + escapeHtml(cell) + '</code></td>';
+            } else {
+              html += '<td>' + escapeHtml(cell) + '</td>';
+            }
+          }
+          html += '</tr>';
+        });
+        html += '</tbody></table></div>';
+        loading.style.display = 'none';
+        wrap.innerHTML = html;
+        wrap.style.display = 'block';
+      })
+      .catch(function () {
+        loading.innerHTML = 'Could not load <code>india/india_us_exiobase_crosswalk.csv</code>. Use <strong>http://localhost:8080/tradeflow/</strong> (or any local server) instead of <code>file://</code>, and ensure the India crosswalk file exists.';
+      });
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  }
+
   // Load diagram on page load
-  waitForElm('#schema-svg').then(() => loadSchemaDiagram());
+  waitForElm('#schema-svg').then(function () {
+    loadSchemaDiagram();
+    loadCrossCountryCrosswalk();
+  });
 
 })();
 </script>

--- a/tradeflow/india/README.md
+++ b/tradeflow/india/README.md
@@ -2,21 +2,21 @@
 
 Allocates national India trade flow and economic data down to the state/UT level, producing matrices that integrate with the Exiobase MRIO pipeline.
 
-## india-state-allocation.py
+## main.py
 
 ### What it processes
 
-Reads national-level Indian economic data and disaggregates it across 36 states and union territories using sector output shares derived from GSDP and GSVA. The five allocation steps are:
+Reads national-level Indian economic data and disaggregates it across 36 states and union territories using sector output shares derived from GSDP and GSVA. Indian activity labels are matched via `india_us_exiobase_crosswalk.csv` to **Exiobase `industry_id`** values (same 5-character codes used in US `trade-data` outputs, enabling India–US comparisons on a common taxonomy). The five allocation steps are:
 
-1. **State × Sector output matrix** — GSDP scaled by GSVA sector shares per state
-2. **State × Product export matrix** — national TradeStat exports allocated to states via sector output proxies; HS codes mapped to Exiobase products
-3. **State × Product import matrix** — national TradeStat imports allocated to states via GSDP proportions; HS codes mapped to Exiobase products
+1. **State × Sector output matrix** — GSDP scaled by GSVA sector shares per state; columns include `industry_id` and `exiobase_industry_name`
+2. **State × Product export matrix** — national TradeStat exports allocated using state output sliced by `industry_id` where HS→Exiobase mapping resolves; HS codes mapped to Exiobase products
+3. **State × Product import matrix** — national TradeStat imports allocated to states via GSDP proportions; includes `industry_id` per product
 4. **State A-matrices** — national Supply Use Table (SUT) technical coefficients scaled per state; used in-memory only, not written to disk
 5. **india_states.csv** — state-level summary of total output, employment (placeholder), and population (placeholder)
 
 ### Uses config.yaml
 
-Yes — reads `../config.yaml` (one level up, in `exiobase/tradeflow/`) via `config_loader.py` for the processing year (`YEAR`) and reference file paths (`industry.csv`). The year can be overridden with `--year`.
+Yes — reads `../config.yaml` (one level up, in `exiobase/tradeflow/`) via `config_loader.py` for the processing year (`YEAR`), `FOLDERS` (default output under `trade-data/year/{YEAR}/IN/domestic/`), and reference `industry.csv`. The pipeline registry includes an `india` node alongside `us_bea`. The year can be overridden with `--year`.
 
 ### Input data
 
@@ -36,13 +36,14 @@ State files (individual Excel files per state) are used as a fallback when conso
 
 ### Output
 
-Sent to `webroot/trade-data/year/2023/IN/domestic/` by default. Override with `--output-dir`.
+Sent to `../../trade-data/year/{YEAR}/IN/domestic/` by default (from `config.yaml` `FOLDERS.domestic` relative to `tradeflow/`). Override with `--output-dir`.
 
 | File | Description |
 |---|---|
-| `state_sector_output.csv` | State × sector output matrix; columns: `state, sector, output, value_added, allocation_method` |
-| `state_product_export.csv` | State × product export matrix; columns: `state, exiobase_product, export_value, hs_code, allocation_method` |
-| `state_product_import.csv` | State × product import matrix; columns: `state, exiobase_product, import_value, hs_code, allocation_method` |
+| `india_us_exiobase_crosswalk.csv` | Keyword-level India GSVA→Exiobase `industry_id` bridge (copy of `india/india_us_exiobase_crosswalk.csv`) |
+| `state_sector_output.csv` | State × sector output matrix; includes `industry_id`, `exiobase_industry_name` |
+| `state_product_export.csv` | State × product export matrix; includes `industry_id` |
+| `state_product_import.csv` | State × product import matrix; includes `industry_id` |
 | `india_states.csv` | State summary; columns: `State, Output, Employment, Population` |
 | `allocation_report.md` | Processing summary with row counts and totals per matrix |
 | `HS_EXIOBASE_mapping.csv` | Saved to `India_data/` on first run if not already present |
@@ -51,16 +52,16 @@ Sent to `webroot/trade-data/year/2023/IN/domestic/` by default. Override with `-
 
 ```bash
 # Run from exiobase/tradeflow/
-python india/india-state-allocation.py
+python india/main.py
 
 # Specify a different data directory
-python india/india-state-allocation.py --data-dir ../India_data
+python india/main.py --data-dir ../India_data
 
 # Specify a year (overrides config.yaml)
-python india/india-state-allocation.py --year 2019
+python india/main.py --year 2019
 
 # Specify a custom output directory
-python india/india-state-allocation.py --output-dir ../../trade-data/year/2019/IN/domestic
+python india/main.py --output-dir ../../trade-data/year/2019/IN/domestic
 ```
 
 ### Dependencies

--- a/tradeflow/india/main.py
+++ b/tradeflow/india/main.py
@@ -9,10 +9,10 @@ Allocates national trade flows and economic data to Indian states/UTs using:
 - TradeStat-Eidb Export and Import data (HS codes)
 - GSDP_Current_2011-12_State_wise for scaling
 
-Usage:
-    python india/india-state-allocation.py
-    python india/india-state-allocation.py --data-dir ../India_data
-    python india/india-state-allocation.py --year 2019
+Usage (from exiobase/tradeflow/):
+    python india/main.py
+    python india/main.py --data-dir ../India_data
+    python india/main.py --year 2019
 """
 
 import sys
@@ -20,6 +20,7 @@ import pandas as pd
 import numpy as np
 import argparse
 import os
+import shutil
 from pathlib import Path
 from datetime import datetime
 import warnings
@@ -35,7 +36,7 @@ except ImportError:
     print("Warning: openpyxl not installed. Excel file support may be limited.")
     print("Install with: pip install openpyxl")
 
-from config_loader import load_config, get_file_path, get_reference_file_path
+from config_loader import load_config, get_reference_file_path
 
 class IndiaStateAllocator:
     def __init__(self, data_dir=None, year=None):
@@ -72,6 +73,8 @@ class IndiaStateAllocator:
         self.import_data = None
         self.hs_exiobase_mapping = None
         self.industry_mapping = None
+        self.india_us_crosswalk = None  # Indian GSVA text -> Exiobase industry_id (same IDs as US trade-data)
+        self._industry_name_and_id_lookup = {}  # name or id -> industry_id
         
         # Output matrices
         self.state_sector_output = None  # State × Sector output matrix
@@ -84,6 +87,8 @@ class IndiaStateAllocator:
         
         # Load industry mapping from reference files
         self._load_industry_mapping()
+        self._load_india_us_crosswalk()
+        self._build_industry_id_lookup()
     
     def _scan_available_files(self):
         """Scan the data directory and catalog available files"""
@@ -158,7 +163,71 @@ class IndiaStateAllocator:
         except Exception as e:
             print(f"Warning: Could not load industry mapping: {e}")
             self.industry_mapping = None
-    
+
+    def _build_industry_id_lookup(self):
+        """Map Exiobase industry name and 5-char industry_id -> industry_id (US and IN share this taxonomy in trade-data)."""
+        self._industry_name_and_id_lookup = {}
+        if self.industry_mapping is None:
+            return
+        for _, row in self.industry_mapping.iterrows():
+            name = str(row["name"]).strip()
+            iid = str(row["industry_id"]).strip()
+            self._industry_name_and_id_lookup[name.lower()] = iid
+            self._industry_name_and_id_lookup[iid.lower()] = iid
+
+    def _load_india_us_crosswalk(self):
+        """
+        Load India GSVA / national-accounts activity keywords -> Exiobase industry_id.
+        The same industry_id values appear in US Exiobase-derived trade outputs, enabling cross-country IO alignment.
+        """
+        path = Path(__file__).resolve().parent / "india_us_exiobase_crosswalk.csv"
+        if not path.exists():
+            print(f"Warning: India–US Exiobase crosswalk not found at {path}")
+            self.india_us_crosswalk = pd.DataFrame(
+                columns=["india_gsva_keyword", "industry_id", "exiobase_industry_name", "alignment_note"]
+            )
+            self._crosswalk_sorted_keywords = []
+            return
+        self.india_us_crosswalk = pd.read_csv(path)
+        # Longest keywords first so e.g. "public administration" wins over "public"
+        kw = self.india_us_crosswalk["india_gsva_keyword"].astype(str).str.strip()
+        order = kw.str.len().sort_values(ascending=False).index
+        self.india_us_crosswalk = self.india_us_crosswalk.loc[order].reset_index(drop=True)
+        self._crosswalk_sorted_keywords = [
+            (str(r.india_gsva_keyword).strip().lower(), str(r.industry_id).strip(), str(r.exiobase_industry_name).strip())
+            for r in self.india_us_crosswalk.itertuples(index=False)
+        ]
+        print(f"Loaded India→Exiobase crosswalk: {len(self.india_us_crosswalk)} keyword rows (shared industry_id with US MRIO outputs)")
+
+    def _match_india_sector_to_exiobase(self, sector_label):
+        """Return (industry_id, exiobase_industry_name) for an Indian sector label."""
+        if sector_label is None or (isinstance(sector_label, float) and np.isnan(sector_label)):
+            return "-1", "Unmapped"
+        s = str(sector_label).strip().lower()
+        if not s:
+            return "-1", "Unmapped"
+        for kw, iid, ename in self._crosswalk_sorted_keywords:
+            if kw and kw in s:
+                return iid, ename
+        if self._industry_name_and_id_lookup:
+            if s in self._industry_name_and_id_lookup:
+                iid = self._industry_name_and_id_lookup[s]
+                sub = self.industry_mapping[self.industry_mapping["industry_id"] == iid]
+                ename = sub["name"].iloc[0] if len(sub) else iid
+                return iid, str(ename)
+        return "-1", "Unmapped"
+
+    def _resolve_industry_id_from_exiobase_label(self, label):
+        """Map HS / pivot product label (name or compact Exiobase code) to 5-char industry_id."""
+        if label is None or (isinstance(label, float) and pd.isna(label)):
+            return "-1"
+        key = str(label).strip().lower()
+        if not key or key == "unmapped":
+            return "-1"
+        if key in self._industry_name_and_id_lookup:
+            return self._industry_name_and_id_lookup[key]
+        return "-1"
+
     def load_india_data(self):
         """Load all India data files"""
         print("\n" + "="*60)
@@ -638,6 +707,7 @@ class IndiaStateAllocator:
         if mapping_file.exists():
             self.hs_exiobase_mapping = pd.read_csv(mapping_file)
             print(f"  ✅ Loaded mapping: {len(self.hs_exiobase_mapping)} entries")
+            self._attach_industry_ids_to_hs_mapping()
         else:
             print(f"  ⚠️ HS-EXIOBASE mapping not found, will create basic mapping")
             self.hs_exiobase_mapping = self._create_basic_hs_mapping()
@@ -645,7 +715,23 @@ class IndiaStateAllocator:
             mapping_file.parent.mkdir(parents=True, exist_ok=True)
             self.hs_exiobase_mapping.to_csv(mapping_file, index=False)
             print(f"  ✅ Created and saved basic mapping: {mapping_file}")
-    
+            self._attach_industry_ids_to_hs_mapping()
+
+    def _attach_industry_ids_to_hs_mapping(self):
+        """Add industry_id for each HS row using Exiobase product/sector labels (same codes as US-side trade-data)."""
+        if self.hs_exiobase_mapping is None or not len(self.hs_exiobase_mapping):
+            return
+
+        def resolve_row(row):
+            for col in ("exiobase_product", "exiobase_sector"):
+                if col in row.index and pd.notna(row[col]):
+                    iid = self._resolve_industry_id_from_exiobase_label(row[col])
+                    if iid != "-1":
+                        return iid
+            return "-1"
+
+        self.hs_exiobase_mapping["industry_id"] = self.hs_exiobase_mapping.apply(resolve_row, axis=1)
+
     def _create_basic_hs_mapping(self):
         """Create a basic HS to EXIOBASE mapping based on commodity categories"""
         # This is a simplified mapping - should be enhanced with actual concordance
@@ -791,6 +877,9 @@ class IndiaStateAllocator:
                         })
         
         self.state_sector_output = pd.DataFrame(state_sector_list)
+        matched = self.state_sector_output["sector"].apply(self._match_india_sector_to_exiobase)
+        self.state_sector_output["industry_id"] = matched.apply(lambda t: t[0])
+        self.state_sector_output["exiobase_industry_name"] = matched.apply(lambda t: t[1])
         
         # Validate: state totals should match GSDP
         validation = self.state_sector_output.groupby('state')['output'].sum()
@@ -860,23 +949,23 @@ class IndiaStateAllocator:
         for product in products:
             national_export_value = national_exports[product]
             
-            # Find which sector this product belongs to
-            sector = product_sector_map.get(product, None)
-            
-            if sector is None:
-                # If no sector mapping, allocate based on total GSDP
+            # industry_id aligns Indian state outputs with US/Exiobase trade-data industry codes
+            industry_id = product_sector_map.get(product, None)
+            if not industry_id or industry_id == "-1":
+                industry_id = self._resolve_industry_id_from_exiobase_label(product)
+            use_industry_slice = industry_id and industry_id != "-1"
+
+            if not use_industry_slice:
                 state_shares = self.state_sector_output.groupby('state')['output'].sum()
                 state_shares = state_shares / state_shares.sum()
             else:
-                # Allocate based on sector output
                 sector_outputs = self.state_sector_output[
-                    self.state_sector_output['sector'] == sector
+                    self.state_sector_output['industry_id'] == industry_id
                 ].groupby('state')['output'].sum()
                 
                 if sector_outputs.sum() > 0:
                     state_shares = sector_outputs / sector_outputs.sum()
                 else:
-                    # Fallback to total GSDP
                     state_shares = self.state_sector_output.groupby('state')['output'].sum()
                     state_shares = state_shares / state_shares.sum()
             
@@ -896,9 +985,10 @@ class IndiaStateAllocator:
                 state_export_list.append({
                     'state': state,
                     'exiobase_product': product,
+                    'industry_id': industry_id if use_industry_slice else self._resolve_industry_id_from_exiobase_label(product),
                     'export_value': state_export_value,
                     'hs_code': hs_code_value,
-                    'allocation_method': 'sector_output' if sector else 'gsdp_proportion'
+                    'allocation_method': 'industry_id_output' if use_industry_slice else 'gsdp_proportion'
                 })
         
         self.state_product_export = pd.DataFrame(state_export_list)
@@ -970,9 +1060,11 @@ class IndiaStateAllocator:
         
         for product in products:
             national_import_value = national_imports[product]
+            industry_id = product_sector_map.get(product, None)
+            if not industry_id or industry_id == "-1":
+                industry_id = self._resolve_industry_id_from_exiobase_label(product)
             
-            # For imports, allocate based on consumption (proxied by GSDP)
-            # More sophisticated: could use sector consumption patterns
+            # For imports, allocate based on consumption (proxied by total state output/GSDP)
             state_shares = self.state_sector_output.groupby('state')['output'].sum()
             state_shares = state_shares / state_shares.sum()
             
@@ -992,6 +1084,7 @@ class IndiaStateAllocator:
                 state_import_list.append({
                     'state': state,
                     'exiobase_product': product,
+                    'industry_id': industry_id,
                     'import_value': state_import_value,
                     'hs_code': hs_code_value,
                     'allocation_method': 'gsdp_proportion'
@@ -1404,23 +1497,24 @@ class IndiaStateAllocator:
         return trade_mapped
     
     def _create_product_sector_map(self):
-        """Create mapping from EXIOBASE products to sectors"""
-        # This is simplified - should use proper EXIOBASE product-sector mapping
+        """Map EXIOBASE product labels (name or 5-char id) to industry_id for state allocation."""
+        product_sector_map = {}
         if self.industry_mapping is not None:
-            # Use industry mapping if available
-            return dict(zip(
-                self.industry_mapping['name'],
-                self.industry_mapping['industry_id']
-            ))
-        else:
-            # Basic mapping based on product names
-            product_sector_map = {}
-            if self.hs_exiobase_mapping is not None:
-                for _, row in self.hs_exiobase_mapping.iterrows():
-                    product = row['exiobase_product']
-                    sector = row.get('exiobase_sector', product)
-                    product_sector_map[product] = sector
-            return product_sector_map
+            for _, row in self.industry_mapping.iterrows():
+                name = row["name"]
+                iid = row["industry_id"]
+                product_sector_map[name] = iid
+                product_sector_map[iid] = iid
+        if self.hs_exiobase_mapping is not None:
+            for _, row in self.hs_exiobase_mapping.iterrows():
+                iid = row["industry_id"] if "industry_id" in row.index else "-1"
+                if pd.isna(iid) or str(iid).strip() == "":
+                    iid = "-1"
+                iid = str(iid).strip()
+                for col in ("exiobase_product", "exiobase_sector"):
+                    if col in row.index and pd.notna(row[col]) and str(row[col]).strip():
+                        product_sector_map[str(row[col]).strip()] = iid
+        return product_sector_map
     
     def _calculate_technical_coefficients(self, sut_df):
         """Calculate technical coefficient matrix (A-matrix) from SUT"""
@@ -1465,21 +1559,19 @@ class IndiaStateAllocator:
         print("="*60)
         
         if output_dir is None:
-    # Save inside: webroot/trade-data/year/2023/IN/domestic
-            project_root = Path(__file__).resolve().parents[3]  # /webroot
-            output_dir = (
-                project_root /
-                "trade-data" /
-                "year" /
-                "2023" /
-                "IN" /
-                "domestic"
-            )
+            tradeflow_root = Path(__file__).resolve().parent.parent
+            rel = self.config["FOLDERS"]["domestic"].format(year=self.year, country="IN")
+            output_dir = (tradeflow_root / rel).resolve()
         else:
             output_dir = Path(output_dir)
         
         output_dir.mkdir(parents=True, exist_ok=True)
         print(f"Output directory: {output_dir}")
+
+        crosswalk_src = Path(__file__).resolve().parent / "india_us_exiobase_crosswalk.csv"
+        if crosswalk_src.exists():
+            shutil.copy(crosswalk_src, output_dir / "india_us_exiobase_crosswalk.csv")
+            print(f"✅ Copied India–US Exiobase crosswalk to: {output_dir / 'india_us_exiobase_crosswalk.csv'}")
         
         # Save state × sector output matrix
         if self.state_sector_output is not None:
@@ -1531,6 +1623,9 @@ class IndiaStateAllocator:
             f.write(f"# India State-Level Allocation Report\n\n")
             f.write(f"**Generated**: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
             f.write(f"**Year**: {self.year}\n\n")
+            f.write("## India–US Exiobase alignment\n\n")
+            f.write("Indian GSVA activity strings map to Exiobase `industry_id` (5-character codes) via ")
+            f.write("`india_us_exiobase_crosswalk.csv` — the same `industry_id` dimension as US `trade-data` outputs.\n\n")
             
             f.write("## Data Sources\n\n")
             f.write(f"- GSDP Data: {len(self.gsdp_data) if self.gsdp_data is not None else 0} records\n")
@@ -1571,7 +1666,7 @@ class IndiaStateAllocator:
         
         print(f"✅ Created summary report: {report_file}")
     
-    def run_full_allocation(self):
+    def run_full_allocation(self, output_dir=None):
         """Run the complete allocation process"""
         print("\n" + "="*80)
         print("INDIA STATE-LEVEL ALLOCATION PROCESS")
@@ -1593,7 +1688,7 @@ class IndiaStateAllocator:
         self.scale_sut_to_states()
         
         # Step 6: Save outputs
-        self.save_outputs()
+        self.save_outputs(output_dir=output_dir)
         
         print("\n" + "="*80)
         print("✅ ALLOCATION PROCESS COMPLETE")
@@ -1645,7 +1740,7 @@ def main():
     try:
         print("Initializing India State Allocation...")
         allocator = IndiaStateAllocator(data_dir=args.data_dir, year=args.year)
-        allocator.run_full_allocation()
+        allocator.run_full_allocation(output_dir=args.output_dir)
         
     except Exception as e:
         print(f"\n❌ Error: {e}")


### PR DESCRIPTION
This PR refactors the India tradeflow pipeline and introduces alignment with Exiobase by mapping Indian GSVA activities and trade data to standardized industry_id codes. These are the same identifiers used in US trade-data, enabling consistent cross-country analysis.

Key Changes
Renamed india-state-allocation.py → india/main.py and updated all references
Added India → Exiobase crosswalk (india_us_exiobase_crosswalk.csv)
Included industry_id (and industry name) in output datasets
Updated export allocation to use industry_id-based slicing where available, with GSDP fallback
Integrated India pipeline into config.yaml with standardized output paths
Updated documentation and UI to reflect new structure and cross-country mapping
Impact
Aligns India outputs with US/Exiobase trade-data schema
Enables direct India–US comparisons on a shared industry taxonomy
Improves consistency for MRIO-based workflows
How to Test
cd tradeflow
python india/main.py --data-dir ../India_data --year 2020

Verify that outputs in trade-data/year/2020/IN/domestic/ include industry_id and the crosswalk file.

Screenshot attached below:

<img width="3840" height="2400" alt="Screenshot (59)" src="https://github.com/user-attachments/assets/5f579d87-809a-47f6-80e8-007f0c00a2d2" />
<img width="3840" height="2400" alt="Screenshot (61)" src="https://github.com/user-attachments/assets/2509e5ec-2f67-4dde-8750-e17ecd6d798b" />
<img width="3840" height="2400" alt="Screenshot (62)" src="https://github.com/user-attachments/assets/fd722b73-d039-4b49-b55d-f3e8de28f237" />
