### PR TITLE
Add trade data insert pipeline and UI

### DIFF
--- a/tradeflow/api.py
+++ b/tradeflow/api.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Flask API for the tradeflow Insert Data UI.
+
+Endpoints:
+  POST /insert  { year, country, flow_type }  -> insert result JSON
+  GET  /schema                                 -> table row counts
+
+Start:
+  python api.py          (port 5002)
+  PORT=8000 python api.py
+"""
+
+import os
+import time
+
+import psycopg2
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+
+from insert_pipeline import insert_trade_data
+
+app = Flask(__name__)
+CORS(app)
+
+
+def _get_conn():
+    return psycopg2.connect(
+        host=os.environ["EXIOBASE_HOST"],
+        port=int(os.environ.get("EXIOBASE_PORT", 5432)),
+        dbname=os.environ["EXIOBASE_NAME"],
+        user=os.environ["EXIOBASE_USER"],
+        password=os.environ["EXIOBASE_PASSWORD"],
+        sslmode=os.environ.get("EXIOBASE_SSL_MODE", "require"),
+    )
+
+
+@app.post("/insert")
+def insert():
+    body = request.get_json(force=True, silent=True) or {}
+    year = body.get("year")
+    country = body.get("country", "").strip().upper()
+    flow_type = body.get("flow_type", "").strip().lower()
+
+    if not year:
+        return jsonify({"error": "year is required"}), 400
+    try:
+        year = int(year)
+    except (ValueError, TypeError):
+        return jsonify({"error": "year must be a number"}), 400
+
+    if not country or len(country) != 2 or not country.isalpha():
+        return jsonify({"error": "country must be a 2-letter code (e.g. US)"}), 400
+
+    if flow_type not in ("domestic", "imports", "exports"):
+        return jsonify({"error": "flow_type must be domestic, imports, or exports"}), 400
+
+    start = time.time()
+    try:
+        result = insert_trade_data(year, country, flow_type)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+    elapsed = round(time.time() - start, 1)
+
+    if result.errors:
+        return jsonify({"error": result.errors[0]}), 400
+
+    return jsonify({
+        "year": year,
+        "country": country,
+        "flow_type": flow_type,
+        "rows_inserted": result.rows_inserted,
+        "rows_skipped": result.rows_skipped,
+        "elapsed_seconds": elapsed,
+    })
+
+
+@app.get("/schema")
+def schema():
+    tables = ["factor", "industry", "trade", "trade_factor", "trade_impact"]
+    try:
+        conn = _get_conn()
+        counts = {}
+        with conn.cursor() as cur:
+            for t in tables:
+                try:
+                    cur.execute(f"SELECT COUNT(*) FROM {t}")
+                    counts[t] = cur.fetchone()[0]
+                except Exception:
+                    counts[t] = None
+        conn.close()
+        return jsonify({"tables": counts})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 5002))
+    print(f"Starting tradeflow API on port {port}")
+    app.run(host="0.0.0.0", port=port, debug=False)

--- a/tradeflow/index.html
+++ b/tradeflow/index.html
@@ -39,6 +39,62 @@ loadMarkdown("README.md", "readmeDiv", "_parent");
 loadMarkdown("CLAUDE.md", "claudeDiv", "_parent");
 </script>
 
+<style>
+#insertForm {
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 16px 20px;
+  margin: 16px 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-end;
+}
+.dark #insertForm {
+  background: #333;
+  border-color: #555;
+}
+#insertForm label {
+  display: flex;
+  flex-direction: column;
+  font-size: 13px;
+  gap: 4px;
+}
+#insertForm select, #insertForm input {
+  padding: 5px 8px;
+  font-size: 14px;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  background: #fff;
+}
+.dark #insertForm select, .dark #insertForm input {
+  background: #444;
+  color: #eee;
+  border-color: #666;
+}
+#insertBtn {
+  padding: 6px 18px;
+  font-size: 14px;
+  background: #4a7c59;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+#insertBtn:disabled {
+  background: #999;
+  cursor: default;
+}
+#insertResult {
+  margin-top: 10px;
+  font-size: 13px;
+  min-height: 20px;
+}
+#insertResult.error { color: #c00; }
+#insertResult.success { color: #2a6; }
+</style>
+
 </head>
 
 <body>
@@ -47,8 +103,77 @@ loadMarkdown("CLAUDE.md", "claudeDiv", "_parent");
     <a href="https://github.com/ModelEarth/exiobase/tree/main/tradeflow"><img src="../../localsite/img/icon/github/github.png" style="width:42px"></a>
   </div>
   <a href="../../profile/trade">Trade Profiles</a>
+
+  <div id="insertForm">
+    <label>Year
+      <select id="selYear">
+        <option value="2022">2022</option>
+        <option value="2021">2021</option>
+        <option value="2020">2020</option>
+        <option value="2019" selected>2019</option>
+      </select>
+    </label>
+    <label>Country
+      <input id="inpCountry" type="text" value="US" maxlength="2" style="width:60px">
+    </label>
+    <label>Flow Type
+      <select id="selFlow">
+        <option value="exports">exports</option>
+        <option value="imports">imports</option>
+        <option value="domestic">domestic</option>
+      </select>
+    </label>
+    <button id="insertBtn" onclick="insertData()">Insert Data</button>
+    <div id="insertResult"></div>
+  </div>
+
   <div id="readmeDiv"></div>
   <div id="claudeDiv"></div>
 </div>
+
+<script>
+const API_BASE = "http://localhost:5002";
+
+async function insertData() {
+  const year = document.getElementById("selYear").value;
+  const country = document.getElementById("inpCountry").value.trim().toUpperCase();
+  const flow_type = document.getElementById("selFlow").value;
+  const btn = document.getElementById("insertBtn");
+  const result = document.getElementById("insertResult");
+
+  if (!country || country.length !== 2) {
+    result.className = "error";
+    result.textContent = "Enter a valid 2-letter country code.";
+    return;
+  }
+
+  btn.disabled = true;
+  result.className = "";
+  result.textContent = `Inserting ${year}/${country}/${flow_type}...`;
+
+  try {
+    const resp = await fetch(`${API_BASE}/insert`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ year: parseInt(year), country, flow_type }),
+    });
+    const data = await resp.json();
+    if (!resp.ok) {
+      result.className = "error";
+      result.textContent = "Error: " + (data.error || resp.statusText);
+    } else {
+      const ins = data.rows_inserted;
+      const parts = Object.entries(ins).map(([t, n]) => `${t}: ${n.toLocaleString()}`);
+      result.className = "success";
+      result.textContent = `Done in ${data.elapsed_seconds}s — ${parts.join(", ")}`;
+    }
+  } catch (e) {
+    result.className = "error";
+    result.textContent = "Could not reach API (is api.py running on port 5002?)";
+  } finally {
+    btn.disabled = false;
+  }
+}
+</script>
 </body>
 </html>

--- a/tradeflow/insert_pipeline.py
+++ b/tradeflow/insert_pipeline.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+Fetches trade CSVs from GitHub and batch-inserts them into Azure industrydb.
+
+Insert order respects FK constraints:
+  factor -> industry -> trade -> trade_factor -> trade_impact
+
+Run directly:
+  python insert_pipeline.py --year 2019 --country US --flow_type exports
+
+Or import and call insert_trade_data() from api.py.
+"""
+
+import argparse
+import io
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pandas as pd
+import psycopg2
+import psycopg2.extras
+import requests
+
+GITHUB_BASE = "https://raw.githubusercontent.com/ModelEarth/trade-data/refs/heads/main/year"
+BATCH_SIZE = 500
+MAX_RETRIES = 3
+
+
+# ---------------------------------------------------------------------------
+# DB connection
+# ---------------------------------------------------------------------------
+
+def _get_conn():
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            conn = psycopg2.connect(
+                host=os.environ["EXIOBASE_HOST"],
+                port=int(os.environ.get("EXIOBASE_PORT", 5432)),
+                dbname=os.environ["EXIOBASE_NAME"],
+                user=os.environ["EXIOBASE_USER"],
+                password=os.environ["EXIOBASE_PASSWORD"],
+                sslmode=os.environ.get("EXIOBASE_SSL_MODE", "require"),
+            )
+            return conn
+        except psycopg2.OperationalError as e:
+            if attempt == MAX_RETRIES:
+                raise
+            time.sleep(2 ** attempt)
+
+
+# ---------------------------------------------------------------------------
+# CSV fetching
+# ---------------------------------------------------------------------------
+
+def _fetch_csv(url: str) -> Optional[pd.DataFrame]:
+    try:
+        r = requests.get(url, timeout=60)
+        if r.status_code == 404:
+            return None
+        r.raise_for_status()
+        return pd.read_csv(io.StringIO(r.text), low_memory=False)
+    except Exception as e:
+        print(f"  Warning: could not fetch {url}: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Batch insert helpers
+# ---------------------------------------------------------------------------
+
+def _batch_insert(cur, sql: str, rows: list):
+    for i in range(0, len(rows), BATCH_SIZE):
+        psycopg2.extras.execute_values(cur, sql, rows[i : i + BATCH_SIZE], page_size=BATCH_SIZE)
+
+
+# ---------------------------------------------------------------------------
+# Per-table insert functions
+# ---------------------------------------------------------------------------
+
+def _insert_factors(cur, df: pd.DataFrame) -> int:
+    if "factor_id" not in df.columns:
+        print("  factor.csv missing factor_id column, skipping")
+        return 0
+    # CSV uses stressor/extension; DB uses name/context
+    name_col = "name" if "name" in df.columns else "stressor"
+    context_col = "context" if "context" in df.columns else "extension"
+    rows = []
+    for _, r in df.iterrows():
+        try:
+            fid = int(r["factor_id"])
+            if fid <= 0:
+                continue
+        except (ValueError, TypeError):
+            continue
+        rows.append((fid, str(r.get("unit", "")), str(r.get(name_col, "")), str(r.get(context_col, ""))))
+    if not rows:
+        return 0
+    sql = """
+        INSERT INTO factor (factor_id, unit, stressor, extension)
+        VALUES %s
+        ON CONFLICT (factor_id) DO NOTHING
+    """
+    _batch_insert(cur, sql, rows)
+    return len(rows)
+
+
+def _insert_industries(cur, df: pd.DataFrame) -> int:
+    required = {"industry_id", "name"}
+    if not required.issubset(df.columns):
+        print(f"  industry.csv missing columns {required - set(df.columns)}, skipping")
+        return 0
+    rows = []
+    for _, r in df.iterrows():
+        iid = str(r["industry_id"]).strip()
+        name = str(r["name"]).strip()
+        if not iid or not name:
+            continue
+        rows.append((iid, name))
+    if not rows:
+        return 0
+    sql = """
+        INSERT INTO industry (industry_id, name)
+        VALUES %s
+        ON CONFLICT (industry_id) DO NOTHING
+    """
+    _batch_insert(cur, sql, rows)
+    return len(rows)
+
+
+def _delete_flow(cur, year: int, country: str, flow_type: str):
+    cur.execute(
+        "DELETE FROM trade_factor WHERE year=%s AND country=%s AND flow_type=%s",
+        (year, country, flow_type),
+    )
+    cur.execute("""
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_name = 'trade_impact'
+        )
+    """)
+    if cur.fetchone()[0]:
+        cur.execute(
+            "DELETE FROM trade_impact WHERE year=%s AND country=%s AND flow_type=%s",
+            (year, country, flow_type),
+        )
+    cur.execute(
+        "DELETE FROM trade WHERE year=%s AND country=%s AND flow_type=%s",
+        (year, country, flow_type),
+    )
+
+
+def _insert_trade(cur, df: pd.DataFrame, flow_type: str, country: str) -> tuple[int, int]:
+    required = {"trade_id", "year", "region1", "region2", "industry1", "industry2", "amount"}
+    if not required.issubset(df.columns):
+        print(f"  trade.csv missing columns {required - set(df.columns)}, skipping")
+        return 0, 0
+    rows = []
+    skipped = 0
+    for _, r in df.iterrows():
+        try:
+            tid = int(r["trade_id"])
+            year = int(r["year"])
+            amount = float(r["amount"])
+            if tid <= 0 or not (amount == amount):  # NaN check
+                skipped += 1
+                continue
+        except (ValueError, TypeError):
+            skipped += 1
+            continue
+        industry1 = str(r["industry1"]).strip()
+        industry2 = str(r["industry2"]).strip()
+        if not industry1 or not industry2:
+            skipped += 1
+            continue
+        rows.append((
+            tid, year, str(r["region1"]), str(r["region2"]),
+            industry1, industry2, amount, flow_type, country,
+        ))
+    if not rows:
+        return 0, skipped
+    sql = """
+        INSERT INTO trade (trade_id, year, region1, region2, industry1, industry2, amount, flow_type, country)
+        VALUES %s
+        ON CONFLICT DO NOTHING
+    """
+    _batch_insert(cur, sql, rows)
+    return len(rows), skipped
+
+
+def _insert_trade_factor(cur, df: pd.DataFrame, year: int, country: str, flow_type: str) -> tuple[int, int]:
+    # CSV uses "level" as the amount column name
+    amount_col = "level" if "level" in df.columns else "amount"
+    required = {"trade_id", "factor_id", amount_col}
+    if not required.issubset(df.columns):
+        print(f"  trade_factor.csv missing columns {required - set(df.columns)}, skipping")
+        return 0, 0
+    rows = []
+    skipped = 0
+    for _, r in df.iterrows():
+        try:
+            tid = int(r["trade_id"])
+            fid = int(r["factor_id"])
+            amount = float(r[amount_col])
+            if tid <= 0 or fid <= 0 or not (amount == amount):
+                skipped += 1
+                continue
+        except (ValueError, TypeError):
+            skipped += 1
+            continue
+        rows.append((tid, year, country, flow_type, fid, amount))
+    if not rows:
+        return 0, skipped
+    sql = """
+        INSERT INTO trade_factor (trade_id, year, country, flow_type, factor_id, level)
+        VALUES %s
+        ON CONFLICT DO NOTHING
+    """
+    _batch_insert(cur, sql, rows)
+    return len(rows), skipped
+
+
+def _insert_trade_impact(cur, df: pd.DataFrame, year: int, country: str, flow_type: str) -> int:
+    # Skipped until trade_impact DB schema is confirmed
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+@dataclass
+class InsertResult:
+    year: int
+    country: str
+    flow_type: str
+    rows_inserted: dict = field(default_factory=dict)
+    rows_skipped: dict = field(default_factory=dict)
+    errors: list = field(default_factory=list)
+
+
+def insert_trade_data(year: int, country: str, flow_type: str) -> InsertResult:
+    result = InsertResult(year=year, country=country, flow_type=flow_type)
+
+    # Validate inputs
+    if not (1990 <= year <= 2030):
+        result.errors.append(f"Invalid year: {year}")
+        return result
+    country = country.strip().upper()
+    if len(country) != 2 or not country.isalpha():
+        result.errors.append(f"Invalid country code: {country}")
+        return result
+    if flow_type not in ("domestic", "imports", "exports"):
+        result.errors.append(f"Invalid flow_type: {flow_type}")
+        return result
+
+    base = f"{GITHUB_BASE}/{year}"
+    flow_base = f"{base}/{country}/{flow_type}"
+
+    print(f"Fetching CSVs for {year}/{country}/{flow_type}...")
+    factor_df = _fetch_csv(f"{base}/factor.csv")
+    industry_df = _fetch_csv(f"{base}/industry.csv")
+    trade_df = _fetch_csv(f"{flow_base}/trade.csv")
+    trade_factor_df = _fetch_csv(f"{flow_base}/trade_factor.csv")
+    trade_impact_df = _fetch_csv(f"{flow_base}/trade_impact.csv")  # optional
+
+    if trade_df is None:
+        result.errors.append(f"trade.csv not found at {flow_base}/trade.csv")
+        return result
+
+    print("Connecting to database...")
+    conn = _get_conn()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                # Reference tables (idempotent)
+                if factor_df is not None:
+                    n = _insert_factors(cur, factor_df)
+                    result.rows_inserted["factor"] = n
+                    print(f"  factor: {n} rows")
+
+                if industry_df is not None:
+                    n = _insert_industries(cur, industry_df)
+                    result.rows_inserted["industry"] = n
+                    print(f"  industry: {n} rows")
+
+                # Clear then re-insert flow-specific tables
+                print(f"  Clearing existing {year}/{country}/{flow_type} rows...")
+                _delete_flow(cur, year, country, flow_type)
+
+                n, skipped = _insert_trade(cur, trade_df, flow_type, country)
+                result.rows_inserted["trade"] = n
+                result.rows_skipped["trade"] = skipped
+                print(f"  trade: {n} inserted, {skipped} skipped")
+
+                if trade_factor_df is not None:
+                    n, skipped = _insert_trade_factor(cur, trade_factor_df, year, country, flow_type)
+                    result.rows_inserted["trade_factor"] = n
+                    result.rows_skipped["trade_factor"] = skipped
+                    print(f"  trade_factor: {n} inserted, {skipped} skipped")
+
+                if trade_impact_df is not None:
+                    n = _insert_trade_impact(cur, trade_impact_df, year, country, flow_type)
+                    result.rows_inserted["trade_impact"] = n
+                    print(f"  trade_impact: {n} inserted")
+
+    finally:
+        conn.close()
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Insert trade data into Azure industrydb")
+    parser.add_argument("--year", type=int, required=True)
+    parser.add_argument("--country", type=str, required=True)
+    parser.add_argument("--flow_type", type=str, required=True, choices=["domestic", "imports", "exports"])
+    args = parser.parse_args()
+
+    result = insert_trade_data(args.year, args.country, args.flow_type)
+    if result.errors:
+        print("Errors:", result.errors)
+    else:
+        print("Done.", result.rows_inserted)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **insert_pipeline.py**: fetches trade CSVs from the GitHub trade-data repo and batch-inserts into Azure industrydb in FK order (factor → industry → trade → trade_factor), 500 rows per batch, idempotent (clears existing rows for year/country/flow_type before inserting)
- **api.py**: Flask API on port 5002 exposing `POST /insert` and `GET /schema`, called by the tradeflow page
- **tradeflow/index.html**: Insert Data form with year, country, and flow_type selectors — shows row counts and elapsed time on completion

## Tested

Verified with 2019/US/exports: factor: 721, industry: 200, trade: 188,735, trade_factor: 5,282 — no errors, completes in ~32s.

## To run locally

```bash
cd webroot/exiobase/tradeflow
python3 -m venv env && source env/bin/activate
pip install flask flask-cors psycopg2-binary requests pandas
set -a && source ../../docker/.env && set +a
python3 api.py
```